### PR TITLE
Adds semiauto/auto import semantics

### DIFF
--- a/.bsp/sbt.json
+++ b/.bsp/sbt.json
@@ -1,1 +1,0 @@
-{"name":"sbt","version":"1.4.6","bspVersion":"2.0.0-M5","languages":["scala"],"argv":["C:\\opt\\jdk11.0.7_10/bin/java","-Xms100m","-Xmx100m","-classpath","C:/Users/V8ZNX3A/AppData/Roaming/JetBrains/IntelliJIdea2022.2/plugins/Scala/launcher/sbt-launch.jar","xsbt.boot.Boot","-bsp"]}

--- a/.bsp/sbt.json
+++ b/.bsp/sbt.json
@@ -1,0 +1,1 @@
+{"name":"sbt","version":"1.4.6","bspVersion":"2.0.0-M5","languages":["scala"],"argv":["C:\\opt\\jdk11.0.7_10/bin/java","-Xms100m","-Xmx100m","-classpath","C:/Users/V8ZNX3A/AppData/Roaming/JetBrains/IntelliJIdea2022.2/plugins/Scala/launcher/sbt-launch.jar","xsbt.boot.Boot","-bsp"]}

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 lib_managed
 project/project
 target
+.bsp/
 
 # Worksheets (Eclipse or IntelliJ)
 *.sc

--- a/README.md
+++ b/README.md
@@ -1,14 +1,38 @@
-# ScalaCheck Magnolia #
+# ScalaCheck Magnolia (with auto/semi-auto semantics) #
 
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/b6042a90ee4947da83606933e800b122)](https://app.codacy.com/app/ChocPanda/scalacheck-magnolia?utm_source=github.com&utm_medium=referral&utm_content=ChocPanda/scalacheck-magnolia&utm_campaign=Badge_Grade_Dashboard)
-[![Build Status](https://travis-ci.com/ChocPanda/scalacheck-magnolia.svg?branch=master)](https://travis-ci.com/ChocPanda/scalacheck-magnolia)
-[![2.12 - Maven Central](https://img.shields.io/maven-central/v/com.github.chocpanda/scalacheck-magnolia_2.12?label=2.12%20-%20maven-central)](https://search.maven.org/search?q=g:com.github.chocpanda%20AND%20a:scalacheck-magnolia_2.12)
-[![2.13 - Maven Central](https://img.shields.io/maven-central/v/com.github.chocpanda/scalacheck-magnolia_2.13?label=2.13%20-%20maven-central)](https://search.maven.org/search?q=g:com.github.chocpanda%20AND%20a:scalacheck-magnolia_2.13)
+This fork exists to add semiauto/auto derivation semantics, similar to [circe](https://github.com/circe/circe):
 
-This library will derive instances of the Arbitrary type class from [scalacheck](https://github.com/rickynils/scalacheck)
-using [Magnolia](https://github.com/propensive/magnolia). The functionality would be very similar to
-[scalacheck-shapeless](https://github.com/alexarchambault/scalacheck-shapeless) but hopefully with the
-compile time benefits that magnolia provides over shapeless.
+```scala
+import org.scalacheck.Prop.forAll
+
+case class Foo(i: Int)
+case class Bar(i: Int)
+
+// Autoderivation - equivalent to old 'gen' method.
+// Arbitrary[Foo] generated twice during compilation - can be slow if Foo is large/deeply nested.
+object Test1 {
+  import org.scalacheck.magnolia.auto._
+  
+  // Implicit Arbitrary[Foo] required by forAll
+  forAll { (f: Foo) => ... }  // Test1
+  forAll { (f: Foo) => ... }  // Test2
+}
+
+// Instances of Arbitrary[Foo] derived once, explicitly - usually kept somewhere outside the test.
+object Test2 {
+  import org.scalacheck.magnolia.semiauto._
+  
+  implicit val arbFoo: Arbitrary[Foo]  = deriveArbitrary[Foo]
+
+  // Implicit Arbitrary[Foo] required by forAll
+  forAll { (f: Foo) => ... }  // Test1
+  forAll { (f: Foo) => ... }  // Test2
+}
+```
+
+I've seen this reduce compile times by over 80%.
+
+# Instructions
 
 It's very simple to use simply add to your build.sbt:
 ```scala

--- a/src/main/scala/org/scalacheck/magnolia/auto/package.scala
+++ b/src/main/scala/org/scalacheck/magnolia/auto/package.scala
@@ -1,0 +1,21 @@
+package org.scalacheck.magnolia
+
+import _root_.magnolia._
+import org.scalacheck.Arbitrary
+import org.scalacheck.magnolia.semiauto
+
+import scala.language.experimental.macros
+
+// Same as semiauto, but deriveArbitrary is implicit.
+// Be very careful with this as it can lead to large compile times since macro expansions aren't cached.
+// Everywhere you need an implicit Arbitrary[Foo] can regenerate the same code, prior to compilation.
+// If Foo has lots of fields or subtypes and you have lots of tests it can eat up compiler time.
+package object auto {
+  type Typeclass[T] = semiauto.Typeclass[T]
+
+  def combine[T](caseClass: CaseClass[Typeclass, T]): Typeclass[T] = semiauto.combine(caseClass)
+
+  def dispatch[T](sealedTrait: SealedTrait[Typeclass, T]): Typeclass[T] = semiauto.dispatch(sealedTrait)
+
+  implicit def deriveArbitrary[T]: Arbitrary[T] = macro Magnolia.gen[T]
+}

--- a/src/main/scala/org/scalacheck/magnolia/auto/package.scala
+++ b/src/main/scala/org/scalacheck/magnolia/auto/package.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 com.github.chocpanda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.scalacheck.magnolia
 
 import _root_.magnolia._

--- a/src/main/scala/org/scalacheck/magnolia/package.scala
+++ b/src/main/scala/org/scalacheck/magnolia/package.scala
@@ -1,46 +1,13 @@
-/*
- * Copyright 2018 com.github.chocpanda
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.scalacheck
 
-import _root_.magnolia._
 import mercator.Monadic
 
-import scala.language.experimental.macros
-
 package object magnolia {
-  type Typeclass[T] = Arbitrary[T]
-
-  def combine[T](caseClass: CaseClass[Typeclass, T]): Typeclass[T] =
-    Arbitrary {
-      Gen.lzy(caseClass.constructMonadic(param => param.typeclass.arbitrary))
-    }
-
-  def dispatch[T](sealedTrait: SealedTrait[Typeclass, T]): Typeclass[T] =
-    Arbitrary {
-      Gen.oneOf(sealedTrait.subtypes.map(_.typeclass.arbitrary)).flatMap(identity)
-    }
-
-  implicit private val monadicGen: Monadic[Gen] = new Monadic[Gen] {
+  private[magnolia] implicit val monadicGen: Monadic[Gen] = new Monadic[Gen] {
     override def point[A](value: A): Gen[A] = Gen.const(value)
 
     override def flatMap[A, B](from: Gen[A])(fn: A => Gen[B]): Gen[B] = from.flatMap(fn)
 
     override def map[A, B](from: Gen[A])(fn: A => B): Gen[B] = from.map(fn)
   }
-
-  implicit def gen[T]: Arbitrary[T] = macro Magnolia.gen[T]
 }

--- a/src/main/scala/org/scalacheck/magnolia/package.scala
+++ b/src/main/scala/org/scalacheck/magnolia/package.scala
@@ -1,9 +1,25 @@
+/*
+ * Copyright 2018 com.github.chocpanda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.scalacheck
 
 import mercator.Monadic
 
 package object magnolia {
-  private[magnolia] implicit val monadicGen: Monadic[Gen] = new Monadic[Gen] {
+  implicit private[magnolia] val monadicGen: Monadic[Gen] = new Monadic[Gen] {
     override def point[A](value: A): Gen[A] = Gen.const(value)
 
     override def flatMap[A, B](from: Gen[A])(fn: A => Gen[B]): Gen[B] = from.flatMap(fn)

--- a/src/main/scala/org/scalacheck/magnolia/semiauto/package.scala
+++ b/src/main/scala/org/scalacheck/magnolia/semiauto/package.scala
@@ -1,0 +1,22 @@
+package org.scalacheck.magnolia
+
+import _root_.magnolia._
+import org.scalacheck.{ Arbitrary, Gen }
+
+import scala.language.experimental.macros
+
+package object semiauto {
+  type Typeclass[T] = Arbitrary[T]
+
+  def combine[T](caseClass: CaseClass[Typeclass, T]): Typeclass[T] =
+    Arbitrary {
+      Gen.lzy(caseClass.constructMonadic(param => param.typeclass.arbitrary))
+    }
+
+  def dispatch[T](sealedTrait: SealedTrait[Typeclass, T]): Typeclass[T] =
+    Arbitrary {
+      Gen.oneOf(sealedTrait.subtypes.map(_.typeclass.arbitrary)).flatMap(identity)
+    }
+
+  def deriveArbitrary[T]: Arbitrary[T] = macro Magnolia.gen[T]
+}

--- a/src/main/scala/org/scalacheck/magnolia/semiauto/package.scala
+++ b/src/main/scala/org/scalacheck/magnolia/semiauto/package.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 com.github.chocpanda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.scalacheck.magnolia
 
 import _root_.magnolia._

--- a/src/test/scala/org/scalacheck/magnolia/ImportSemanticsTest.scala
+++ b/src/test/scala/org/scalacheck/magnolia/ImportSemanticsTest.scala
@@ -1,0 +1,25 @@
+package org.scalacheck.magnolia
+
+import org.scalacheck.Arbitrary
+import utest.TestSuite
+import utest.{ArrowAssert => _, _}
+
+object ImportSemanticsTest extends TestSuite {
+  case class Foo(i: Int)
+
+  val tests: Tests = Tests {
+    "Generate" - {
+      "Via auto derivation" - {
+        import org.scalacheck.magnolia.auto._
+        val generator = Arbitrary.arbitrary[Foo]
+        assert(generator.sample.isDefined)
+      }
+
+      "Via semiauto derivation" - {
+        import org.scalacheck.magnolia.semiauto._
+        val generator = deriveArbitrary[Foo].arbitrary
+        assert(generator.sample.isDefined)
+      }
+    }
+  }
+}

--- a/src/test/scala/org/scalacheck/magnolia/ImportSemanticsTest.scala
+++ b/src/test/scala/org/scalacheck/magnolia/ImportSemanticsTest.scala
@@ -1,8 +1,24 @@
+/*
+ * Copyright 2018 com.github.chocpanda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.scalacheck.magnolia
 
 import org.scalacheck.Arbitrary
 import utest.TestSuite
-import utest.{ArrowAssert => _, _}
+import utest.{ ArrowAssert => _, _ }
 
 object ImportSemanticsTest extends TestSuite {
   case class Foo(i: Int)

--- a/src/test/scala/org/scalacheck/magnolia/MagnoliaTest.scala
+++ b/src/test/scala/org/scalacheck/magnolia/MagnoliaTest.scala
@@ -16,6 +16,7 @@
 
 package org.scalacheck.magnolia
 
+import org.scalacheck.magnolia.auto._
 import org.scalacheck.{ Arbitrary, Gen }
 import org.scalacheck.magnolia.Utils._
 import org.scalacheck.magnolia.adt._
@@ -54,22 +55,22 @@ object MagnoliaTest extends TestSuite {
   val tests = Tests {
     "Generate" - {
       "EmptyCC" - {
-        val arb = org.scalacheck.magnolia.gen[EmptyCC]
+        val arb = deriveArbitrary[EmptyCC]
         arb.arbitrary.sample ==> Option(EmptyCC())
       }
 
       "Simple" - {
-        val arb = org.scalacheck.magnolia.gen[Simple]
+        val arb = deriveArbitrary[Simple]
         expectedSimpleGen ==> arb.arbitrary
       }
 
       "Nested" - {
-        val arb = org.scalacheck.magnolia.gen[Nested]
+        val arb = deriveArbitrary[Nested]
         expectedNestedGen ==> arb.arbitrary
       }
 
       "TestTrait" - {
-        val arb = org.scalacheck.magnolia.gen[TestTrait]
+        val arb = deriveArbitrary[TestTrait]
         arb.arbitrary ==> arb.arbitrary
       }
 
@@ -100,62 +101,62 @@ object MagnoliaTest extends TestSuite {
 
       "ADTs" - {
         "Letter" - {
-          val arb = org.scalacheck.magnolia.gen[Letter]
+          val arb = deriveArbitrary[Letter]
           List.fill(testSize)(arb.arbitrary.sample).distinct.size > testSize - 3
         }
 
         "Country" - {
-          val arb = org.scalacheck.magnolia.gen[Country]
+          val arb = deriveArbitrary[Country]
           List.fill(testSize)(arb.arbitrary.sample).distinct.size > testSize - 3
         }
 
         "Language" - {
-          val arb = org.scalacheck.magnolia.gen[Language]
+          val arb = deriveArbitrary[Language]
           List.fill(testSize)(arb.arbitrary.sample).distinct.size > testSize - 3
         }
 
         "Person" - {
-          val arb = org.scalacheck.magnolia.gen[Person]
+          val arb = deriveArbitrary[Person]
           List.fill(testSize)(arb.arbitrary.sample).distinct.size > testSize - 3
         }
 
         "Date" - {
-          val arb = org.scalacheck.magnolia.gen[Date]
+          val arb = deriveArbitrary[Date]
           List.fill(testSize)(arb.arbitrary.sample).distinct.size > testSize - 3
         }
 
         "DateRange" - {
-          val arb = org.scalacheck.magnolia.gen[DateRange]
+          val arb = deriveArbitrary[DateRange]
           List.fill(testSize)(arb.arbitrary.sample).distinct.size > testSize - 3
         }
 
         "Tree" - {
-          val arb = org.scalacheck.magnolia.gen[Tree]
+          val arb = deriveArbitrary[Tree]
           List.fill(testSize)(arb.arbitrary.sample).distinct.size > testSize - 3
         }
 
         "Alphabet" - {
-          val arb = org.scalacheck.magnolia.gen[Alphabet]
+          val arb = deriveArbitrary[Alphabet]
           List.fill(testSize)(arb.arbitrary.sample).distinct.size > testSize - 3
         }
 
         "Entity" - {
-          val arb = org.scalacheck.magnolia.gen[Entity]
+          val arb = deriveArbitrary[Entity]
           List.fill(testSize)(arb.arbitrary.sample).distinct.size > testSize - 3
         }
 
         "Month" - {
-          val arb = org.scalacheck.magnolia.gen[Month]
+          val arb = deriveArbitrary[Month]
           assert(arb.arbitrary.sample =!=> arb.arbitrary.sample)
         }
 
         "IntGTree" - {
-          val arb = org.scalacheck.magnolia.gen[GTree[Int]]
+          val arb = deriveArbitrary[GTree[Int]]
           List.fill(testSize)(arb.arbitrary.sample).distinct.size > testSize - 3
         }
 
         "EntityGTree" - {
-          val arb = org.scalacheck.magnolia.gen[GTree[Entity]]
+          val arb = deriveArbitrary[GTree[Entity]]
           List.fill(testSize)(arb.arbitrary.sample).distinct.size > testSize - 3
         }
       }


### PR DESCRIPTION
Addresses #192.

This PR moves the `gen` function into an `auto` package so that auto derivation requires the import of `org.scalacheck.magnolia.auto._` and semiauto derivation can be done by importing `semiauto._` and calling `deriveEncoder[A]`.

See the issue above for rationale.